### PR TITLE
Add Python virtual environment setup instructions and image placeholders

### DIFF
--- a/1 - hello world.ipynb
+++ b/1 - hello world.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "image-placeholder",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3867e53f-be36-4181-9e2b-5539736f16fa",
    "metadata": {},
    "source": [
@@ -240,7 +248,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+   "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/2 - summarize.ipynb
+++ b/2 - summarize.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "placeholder-image",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d5b71c9-dacd-49e0-bb4b-c98398b0396a",
    "metadata": {},
    "source": [

--- a/3 - chat.ipynb
+++ b/3 - chat.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "image-placeholder",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "947468ef-9ab4-4b81-89b5-305ba4edbd94",
    "metadata": {},
    "source": [

--- a/4 - RAG.ipynb
+++ b/4 - RAG.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "placeholder-image",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f0a5a431-028a-4657-b6e0-ede6af1e8a82",
    "metadata": {},
    "source": [

--- a/5 - schema_extraction.ipynb
+++ b/5 - schema_extraction.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "placeholder-image",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "33b99b7e-20b1-4d61-9a12-246672063f2f",
    "metadata": {},
    "source": [

--- a/6 - tools.ipynb
+++ b/6 - tools.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "placeholder-image",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "333d752e-589e-4d79-a39c-32c11bdfbcbf",
    "metadata": {},
    "source": [

--- a/7 - agents.ipynb
+++ b/7 - agents.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "image-placeholder",
+   "metadata": {},
+   "source": [
+    "![](../assets/placeholder.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1e7e636c-3282-490a-80ef-720013e926ae",
    "metadata": {},
    "source": [

--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ To get started with these notebooks, you will need to set up your environment:
 2. Install the required dependencies listed in `requirements.txt` by running `pip install -r requirements.txt`.
 3. Ensure you have Jupyter installed to run the notebooks. If not, it can be installed via pip with `pip install jupyter`.
 
+## Setting Up a Python Virtual Environment
+
+To ensure a consistent environment for running these notebooks, it's recommended to use a Python virtual environment. Here are the steps to set up a virtual environment on major operating systems:
+
+### macOS and Linux:
+
+1. Open a terminal.
+2. Navigate to the project directory.
+3. Run `python3 -m venv llm_env` to create a virtual environment named `llm_env`.
+4. Activate the virtual environment by running `source llm_env/bin/activate`.
+
+### Windows:
+
+1. Open Command Prompt.
+2. Navigate to the project directory.
+3. Run `python -m venv llm_env` to create a virtual environment named `llm_env`.
+4. Activate the virtual environment by running `.\llm_env\Scripts\activate`.
+
+To deactivate the virtual environment, simply run `deactivate` in your terminal or Command Prompt.
+
 ## Environment Variables
 
 Some notebooks require API keys to access external services like OpenAI, Langchain, and Google API. To set these up:


### PR DESCRIPTION
Adds instructions for setting up a Python virtual environment on major operating systems and placeholder cells for images at the start of each notebook to the `gpsandhu23/llm_intro_notebooks` repository.

- Updates `README.md` to include a new section titled "Setting Up a Python Virtual Environment" with detailed instructions for macOS, Windows, and Linux.
- Adds a markdown cell with placeholder text for an image at the beginning of each Jupyter notebook (`1 - hello world.ipynb` through `7 - agents.ipynb`), ensuring consistency across all introductory notebooks.
- The placeholder text for images is formatted as `![](../assets/placeholder.png)`, preparing for future image additions in the specified directory.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gpsandhu23/llm_intro_notebooks?shareId=08b21fc0-961e-40ab-9f79-5b98bf936ac2).